### PR TITLE
Update are-you-registering-for-gas-or-electricity.html

### DIFF
--- a/app/views/are-you-registering-for-gas-or-electricity.html
+++ b/app/views/are-you-registering-for-gas-or-electricity.html
@@ -21,6 +21,9 @@ What type of energy are you registering to get a discount for? – {{ serviceNam
         classes: "govuk-fieldset__legend--l"
         }
       },
+      hint: {
+        text: 'You can only register for a discount for gas or electricity supplied by a licenced energy supplier.'
+      },
       items: [
         {
           value: "gas",

--- a/app/views/are-you-registering-for-gas-or-electricity.html
+++ b/app/views/are-you-registering-for-gas-or-electricity.html
@@ -1,7 +1,7 @@
 {% extends "layouts/main.html" %}
 
 {% block pageTitle %}
-Are you registering for a discount for gas or electricity? – {{ serviceName }}
+What type of energy are you registering to get a discount for? – {{ serviceName }}
 {% endblock %}
 
 {% block beforeContent %}
@@ -16,7 +16,7 @@ Are you registering for a discount for gas or electricity? – {{ serviceName }}
       name: "gas-or-electricity",
       fieldset: {
       legend: {
-        text: "Are you registering for a discount for gas or electricity?",
+        text: "What type of energy are you registering to get a discount for?",
         isPageHeading: true,
         classes: "govuk-fieldset__legend--l"
         }


### PR DESCRIPTION
Missing hint text needs to be added.  Should say "You can only register for a discount for gas or electricity supplied by a licenced energy supplier."